### PR TITLE
Revise the Crunchbase - FIBO example to reflect the Q1 2024 FIBO release

### DIFF
--- a/README.html
+++ b/README.html
@@ -708,17 +708,17 @@ And for IPOs that use the same currency for their 3 financials, only 1 pair of n
 But CB uses ISO 4217 standard currency codes, and FIBO already includes such data in the ontology <code>FND/Accounting/ISO4217-CurrencyCodes.rdf</code>, e.g.:</p>
 <pre class="ttl"><code>fibo-fnd-acc-4217:USD
   rdf:type           fibo-fnd-acc-cur:CurrencyIdentifier , owl:NamedIndividual ;
-  lcc-lr:hasTag      &quot;USD&quot; ;
+  fibo-fnd-rel-rel:hasTag      &quot;USD&quot; ;
   rdfs:label         &quot;USD&quot; ;
-  lcc-lr:denotes     fibo-fnd-acc-4217:USDollar ;
-  lcc-lr:identifies  fibo-fnd-acc-4217:USDollar ;
+  cmns-dsg:denotes     fibo-fnd-acc-4217:USDollar ;
+  cmns-id:identifies  fibo-fnd-acc-4217:USDollar ;
 
 fibo-fnd-acc-4217:USDollar
   rdf:type                       fibo-fnd-acc-cur:Currency , owl:NamedIndividual ;
-  lcc-lr:hasName                 &quot;US Dollar&quot; .
+  cmns-dsg:hasName                 &quot;US Dollar&quot; .
   rdfs:label                     &quot;US Dollar&quot; ;
   fibo-fnd-acc-cur:hasNumericCode &quot;840&quot; ;
-  lcc-cr:isUsedBy                lcc-3166-1:VirginIslandsBritish ...</code></pre>
+  cmns-cxtdsg:isUsedBy                lcc-3166-1:VirginIslandsBritish ...</code></pre>
 <p>So why didn't I reuse the FIBO currency nodes and instead made CB currency nodes?
 The reason is subtle and is described in <a href="https://github.com/edmcouncil/fibo/issues/1816">fibo/issues/1816</a>:</p>
 <ul>
@@ -738,7 +738,7 @@ The EDM Council has agreed to change the node names a bit to:</p>
 <pre class="sparql"><code>construct {
   ?curr owl:sameAs ?currAsCode
 } where {
-  ?code a fibo-fnd-acc-cur:CurrencyIdentifier; lcc-lr:hasTag ?c; lcc-lr:identifies ?curr.
+  ?code a fibo-fnd-acc-cur:CurrencyIdentifier; fibo-fnd-rel-rel:hasTag ?c; cmns-id:identifies ?curr.
   bind(iri(concat(str(fibo-fnd-acc-4217:),&quot;Currency-&quot;,?c)) as ?currAsCode)
 }</code></pre>
 <p>This will effectively add alias URLs for each currency (the two <code>sameAs</code> URLs shown above),
@@ -788,12 +788,12 @@ Concatenating any Turtle files produces a valid turtle file, since <code>@prefix
 It mirrors the simplicity of semantic data integration by "simply" converting any kind of data to RDF, using consistent URLs, and "pouring" all data into a semantic repository.</p>
 <p>I have used some <code>rdfpuml</code> (PlantUML) layout instructions in the models to improve the look of the overall model.
 These specify the direction and length of a few arrows, and set colored circles for the classes (<code>stereotype</code>)</p>
-<pre class="ttl"><code>lcc-lr:identifies              puml:arrow puml:up.
-fibo-fnd-rel-rel:hasIdentity   puml:arrow puml:up.
-fibo-fnd-utl-alx:hasArgument   puml:arrow puml:up.
+<pre class="ttl"><code>cmns-id:identifies              puml:arrow puml:up.
+cmns-rlcmp:isPlayedBy   puml:arrow puml:up.
+cmns-qtu:hasArgument   puml:arrow puml:up.
 fibo-fnd-acc-cur:isPriceFor    puml:arrow puml:up.
 fibo-fnd-rel-rel:isIssuedBy    puml:arrow puml:up.
-fibo-fnd-rel-rel:appliesTo     puml:arrow puml:up.
+cmns-cxtdsg:appliesTo     puml:arrow puml:up.
 fibo-fbc-fi-fi:isDenominatedIn puml:arrow puml:down-4.
 
 fibo-fbc-fct-mkt:Exchange             puml:stereotype &quot;(X,lightblue)&quot;.  # also fibo-fbc-fct-ra:RegistrationAuthority
@@ -808,9 +808,9 @@ fibo-sec-sec-id:TickerSymbol          puml:stereotype &quot;(T,lightgreen)&quot;
 fibo-sec-sec-iss:PublicOffering       puml:stereotype &quot;(O,yellow)&quot;.
 fibo-sec-sec-lst:ListedSecurity       puml:stereotype &quot;(S,yellow)&quot;.     # also fibo-sec-eq-eq:Share
 fibo-sec-sec-lst:Listing              puml:stereotype &quot;(L,yellow)&quot;.
-lcc-lr:CodeSet                        puml:stereotype &quot;(C,lightgreen)&quot;.
-lcc-lr:IdentificationScheme           puml:stereotype &quot;(S,lightgreen)&quot;. # also lcc-lr:CodeSet
-lcc-lr:Identifier                     puml:stereotype &quot;(I,lightgreen)&quot;.</code></pre>
+cmns-cds:CodeSet                        puml:stereotype &quot;(C,lightgreen)&quot;.
+cmns-id:IdentificationScheme           puml:stereotype &quot;(S,lightgreen)&quot;. # also cmns-cds:CodeSet
+cmns-id:Identifier                     puml:stereotype &quot;(I,lightgreen)&quot;.</code></pre>
 <h2 data-number="4.7" id="generating-semantic-transformation"><span class="header-section-number">4.7</span> Generating Semantic Transformation</h2>
 <p>Although the FIBO IPO model is considerably more complex than the CB IPO model,
 we can use the <code>rdf2sparql</code> script (part of the <a href="https://github.com/VladimirAlexiev/rdf2rml">RDF by Example</a> open source project)

--- a/README.html
+++ b/README.html
@@ -755,6 +755,14 @@ so now external data like CB can safely refer to <strong>currency</strong> nodes
 </ul>
 <pre class="ttl"><code>@prefix cb:   &lt;https://ontotext.com/crunchbase/ontology/&gt; .
 
+@prefix cmns-cds: &lt;https://www.omg.org/spec/Commons/CodesAndCodeSets/&gt; .
+@prefix cmns-col: &lt;https://www.omg.org/spec/Commons/Collections/&gt; .
+@prefix cmns-dsg: &lt;https://www.omg.org/spec/Commons/Designators/&gt; .
+@prefix cmns-dt: &lt;https://www.omg.org/spec/Commons/DatesAndTimes/&gt; .
+@prefix cmns-cxtdsg: &lt;https://www.omg.org/spec/Commons/ContextualDesignators/&gt; .
+@prefix cmns-id: &lt;https://www.omg.org/spec/Commons/Identifiers/&gt; .
+@prefix cmns-qtu: &lt;https://www.omg.org/spec/Commons/QuantitiesAndUnits/&gt; .
+@prefix cmns-rlcmp: &lt;https://www.omg.org/spec/Commons/RolesAndCompositions/&gt; .
 @prefix fibo-fbc-fct-mkt:  &lt;https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/Markets/&gt; .
 @prefix fibo-fbc-fct-ra:   &lt;https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/&gt; .
 @prefix fibo-fbc-fi-fi:    &lt;https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/&gt; .
@@ -762,15 +770,12 @@ so now external data like CB can safely refer to <strong>currency</strong> nodes
 @prefix fibo-fnd-acc-cur:  &lt;https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/&gt; .
 @prefix fibo-fnd-agr-ctr:  &lt;https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/&gt; .
 @prefix fibo-fnd-arr-id:   &lt;https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/IdentifiersAndIndices/&gt; .
-@prefix fibo-fnd-dt-fd:    &lt;https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/&gt; .
 @prefix fibo-fnd-rel-rel:  &lt;https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/&gt; .
-@prefix fibo-fnd-utl-alx:  &lt;https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/&gt; .
 @prefix fibo-ind-mkt-bas:  &lt;https://spec.edmcouncil.org/fibo/ontology/IND/MarketIndices/BasketIndices/&gt; .
 @prefix fibo-sec-eq-eq:    &lt;https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/&gt; .
 @prefix fibo-sec-sec-id:   &lt;https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIdentification/&gt; .
 @prefix fibo-sec-sec-iss:  &lt;https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/&gt; .
-@prefix fibo-sec-sec-lst:  &lt;https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/&gt; .
-@prefix lcc-lr:            &lt;https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/&gt; .</code></pre>
+@prefix fibo-sec-sec-lst:  &lt;https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/&gt; .</code></pre>
 <p>What is the reason for this complexity?</p>
 <ul>
 <li>FIBO distinguishes between Offering (the IPO), Share, Listing (of the share at an exchange), Ticker (a <code>ReassignableIdentifier</code>)</li>
@@ -788,7 +793,7 @@ Concatenating any Turtle files produces a valid turtle file, since <code>@prefix
 It mirrors the simplicity of semantic data integration by "simply" converting any kind of data to RDF, using consistent URLs, and "pouring" all data into a semantic repository.</p>
 <p>I have used some <code>rdfpuml</code> (PlantUML) layout instructions in the models to improve the look of the overall model.
 These specify the direction and length of a few arrows, and set colored circles for the classes (<code>stereotype</code>)</p>
-<pre class="ttl"><code>cmns-id:identifies              puml:arrow puml:up.
+<pre class="ttl"><code>cmns-id:identifies   puml:arrow puml:up.
 cmns-rlcmp:isPlayedBy   puml:arrow puml:up.
 cmns-qtu:hasArgument   puml:arrow puml:up.
 fibo-fnd-acc-cur:isPriceFor    puml:arrow puml:up.
@@ -808,9 +813,9 @@ fibo-sec-sec-id:TickerSymbol          puml:stereotype &quot;(T,lightgreen)&quot;
 fibo-sec-sec-iss:PublicOffering       puml:stereotype &quot;(O,yellow)&quot;.
 fibo-sec-sec-lst:ListedSecurity       puml:stereotype &quot;(S,yellow)&quot;.     # also fibo-sec-eq-eq:Share
 fibo-sec-sec-lst:Listing              puml:stereotype &quot;(L,yellow)&quot;.
-cmns-cds:CodeSet                        puml:stereotype &quot;(C,lightgreen)&quot;.
-cmns-id:IdentificationScheme           puml:stereotype &quot;(S,lightgreen)&quot;. # also cmns-cds:CodeSet
-cmns-id:Identifier                     puml:stereotype &quot;(I,lightgreen)&quot;.</code></pre>
+cmns-cds:CodeSet                      puml:stereotype &quot;(C,lightgreen)&quot;.
+cmns-id:IdentificationScheme          puml:stereotype &quot;(S,lightgreen)&quot;. # also cmns-cds:CodeSet
+cmns-id:Identifier                    puml:stereotype &quot;(I,lightgreen)&quot;.</code></pre>
 <h2 data-number="4.7" id="generating-semantic-transformation"><span class="header-section-number">4.7</span> Generating Semantic Transformation</h2>
 <p>Although the FIBO IPO model is considerably more complex than the CB IPO model,
 we can use the <code>rdf2sparql</code> script (part of the <a href="https://github.com/VladimirAlexiev/rdf2rml">RDF by Example</a> open source project)

--- a/README.html
+++ b/README.html
@@ -751,7 +751,7 @@ so now external data like CB can safely refer to <strong>currency</strong> nodes
 <li>It has 25 nodes, of which 11 are shared with other IPOs (the currencies and currency codes) and 14 are per-IPO</li>
 <li>It has 136 triples; compare to the simplest model that uses 1 node and 22 triples
 </li>
-<li>It uses terms from 16 FIBO ontologies (see <a href="prefixes.ttl">prefixes.ttl</a>).</li>
+<li>It uses terms from 13 FIBO ontologies and 8 ontologies from the Object Management Group (OMG)'s Commons Ontology Library (see <a href="prefixes.ttl">prefixes.ttl</a>).</li>
 </ul>
 <pre class="ttl"><code>@prefix cb:   &lt;https://ontotext.com/crunchbase/ontology/&gt; .
 

--- a/README.md
+++ b/README.md
@@ -349,27 +349,32 @@ It's a complex graph:
 - It has 25 nodes, of which 11 are shared with other IPOs (the currencies and currency codes) and 14 are per-IPO
 - It has 136 triples; compare to the simplest model that uses 1 node and 22 triples
 <!-- cat prefixes.ttl ipos-fibo.ttl | riot -syntax ttl -out ntriples | grep -vi plantuml | wc -l -->
-- It uses terms from 16 FIBO ontologies (see [prefixes.ttl](prefixes.ttl)).
+- It uses terms from 13 FIBO ontologies and 8 from the Object Managemnt Group (OMG)'s Commons Ontology Library (see [prefixes.ttl](prefixes.ttl)).
 
 ```ttl
 @prefix cb:   <https://ontotext.com/crunchbase/ontology/> .
 
-@prefix fibo-fbc-fct-mkt:  <https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/Markets/> .
-@prefix fibo-fbc-fct-ra:   <https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/> .
-@prefix fibo-fbc-fi-fi:    <https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/> .
+@prefix cmns-cds: <https://www.omg.org/spec/Commons/CodesAndCodeSets/> .
+@prefix cmns-col: <https://www.omg.org/spec/Commons/Collections/> .
+@prefix cmns-dsg: <https://www.omg.org/spec/Commons/Designators/> .
+@prefix cmns-dt: <https://www.omg.org/spec/Commons/DatesAndTimes/> .
+@prefix cmns-cxtdsg: <https://www.omg.org/spec/Commons/ContextualDesignators/> .
+@prefix cmns-id: <https://www.omg.org/spec/Commons/Identifiers/> .
+@prefix cmns-qtu: <https://www.omg.org/spec/Commons/QuantitiesAndUnits/> .
+@prefix cmns-rlcmp: <https://www.omg.org/spec/Commons/RolesAndCompositions/> .
+@prefix fibo-fbc-fct-mkt: <https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/Markets/> .
+@prefix fibo-fbc-fct-ra:  <https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/> .
+@prefix fibo-fbc-fi-fi:   <https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/> .
 @prefix fibo-fbc-pas-fpas: <https://spec.edmcouncil.org/fibo/ontology/FBC/ProductsAndServices/FinancialProductsAndServices/> .
-@prefix fibo-fnd-acc-cur:  <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/> .
-@prefix fibo-fnd-agr-ctr:  <https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/> .
-@prefix fibo-fnd-arr-id:   <https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/IdentifiersAndIndices/> .
-@prefix fibo-fnd-dt-fd:    <https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/> .
-@prefix fibo-fnd-rel-rel:  <https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/> .
-@prefix fibo-fnd-utl-alx:  <https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/> .
-@prefix fibo-ind-mkt-bas:  <https://spec.edmcouncil.org/fibo/ontology/IND/MarketIndices/BasketIndices/> .
-@prefix fibo-sec-eq-eq:    <https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/> .
-@prefix fibo-sec-sec-id:   <https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIdentification/> .
+@prefix fibo-fnd-acc-cur: <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/> .
+@prefix fibo-fnd-agr-ctr: <https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/> .
+@prefix fibo-fnd-arr-id:  <https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/IdentifiersAndIndices/> .
+@prefix fibo-fnd-rel-rel: <https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/> .
+@prefix fibo-ind-mkt-bas: <https://spec.edmcouncil.org/fibo/ontology/IND/MarketIndices/BasketIndices/> .
+@prefix fibo-sec-eq-eq:   <https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/> .
+@prefix fibo-sec-sec-id:  <https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIdentification/> .
 @prefix fibo-sec-sec-iss:  <https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/> .
-@prefix fibo-sec-sec-lst:  <https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/> .
-@prefix lcc-lr:            <https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/> .
+@prefix fibo-sec-sec-lst: <https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/> .
 ```
 
 What is the reason for this complexity?

--- a/README.md
+++ b/README.md
@@ -288,17 +288,17 @@ But CB uses ISO 4217 standard currency codes, and FIBO already includes such dat
 ```ttl
 fibo-fnd-acc-4217:USD
   rdf:type           fibo-fnd-acc-cur:CurrencyIdentifier , owl:NamedIndividual ;
-  lcc-lr:hasTag      "USD" ;
+  fibo-fnd-rel-rel:hasTag      "USD" ;
   rdfs:label         "USD" ;
-  lcc-lr:denotes     fibo-fnd-acc-4217:USDollar ;
-  lcc-lr:identifies  fibo-fnd-acc-4217:USDollar ;
+  cmns-dsg:denotes     fibo-fnd-acc-4217:USDollar ;
+  cmns-id:identifies  fibo-fnd-acc-4217:USDollar ;
 
 fibo-fnd-acc-4217:USDollar
   rdf:type                       fibo-fnd-acc-cur:Currency , owl:NamedIndividual ;
-  lcc-lr:hasName                 "US Dollar" .
+  cmns-dsg:hasName                 "US Dollar" .
   rdfs:label                     "US Dollar" ;
   fibo-fnd-acc-cur:hasNumericCode "840" ;
-  lcc-cr:isUsedBy                lcc-3166-1:VirginIslandsBritish ...
+  cmns-cxtdsg:isUsedBy                lcc-3166-1:VirginIslandsBritish ...
 ```
 
 So why didn't I reuse the FIBO currency nodes and instead made CB currency nodes?
@@ -330,7 +330,7 @@ Generated with the following SPARQL query:
 construct {
   ?curr owl:sameAs ?currAsCode
 } where {
-  ?code a fibo-fnd-acc-cur:CurrencyIdentifier; lcc-lr:hasTag ?c; lcc-lr:identifies ?curr.
+  ?code a fibo-fnd-acc-cur:CurrencyIdentifier; fibo-fnd-rel-rel:hasTag ?c; cmns-id:identifies ?curr.
   bind(iri(concat(str(fibo-fnd-acc-4217:),"Currency-",?c)) as ?currAsCode)
 }
 ```
@@ -395,12 +395,12 @@ I have used some `rdfpuml` (PlantUML) layout instructions in the models to impro
 These specify the direction and length of a few arrows, and set colored circles for the classes (`stereotype`)
 
 ```ttl
-lcc-lr:identifies              puml:arrow puml:up.
-fibo-fnd-rel-rel:hasIdentity   puml:arrow puml:up.
-fibo-fnd-utl-alx:hasArgument   puml:arrow puml:up.
+cmns-id:identifies              puml:arrow puml:up.
+cmns-rlcmp:isPlayedBy   puml:arrow puml:up.
+cmns-qtu:hasArgument   puml:arrow puml:up.
 fibo-fnd-acc-cur:isPriceFor    puml:arrow puml:up.
 fibo-fnd-rel-rel:isIssuedBy    puml:arrow puml:up.
-fibo-fnd-rel-rel:appliesTo     puml:arrow puml:up.
+cmns-cxtdsg:appliesTo     puml:arrow puml:up.
 fibo-fbc-fi-fi:isDenominatedIn puml:arrow puml:down-4.
 
 fibo-fbc-fct-mkt:Exchange             puml:stereotype "(X,lightblue)".  # also fibo-fbc-fct-ra:RegistrationAuthority
@@ -415,9 +415,9 @@ fibo-sec-sec-id:TickerSymbol          puml:stereotype "(T,lightgreen)".
 fibo-sec-sec-iss:PublicOffering       puml:stereotype "(O,yellow)".
 fibo-sec-sec-lst:ListedSecurity       puml:stereotype "(S,yellow)".     # also fibo-sec-eq-eq:Share
 fibo-sec-sec-lst:Listing              puml:stereotype "(L,yellow)".
-lcc-lr:CodeSet                        puml:stereotype "(C,lightgreen)".
-lcc-lr:IdentificationScheme           puml:stereotype "(S,lightgreen)". # also lcc-lr:CodeSet
-lcc-lr:Identifier                     puml:stereotype "(I,lightgreen)".
+cmns-cds:CodeSet                        puml:stereotype "(C,lightgreen)".
+cmns-id:IdentificationScheme           puml:stereotype "(S,lightgreen)". # also cmns-cds:CodeSet
+cmns-id:Identifier                     puml:stereotype "(I,lightgreen)".
 ```
 
 ## Generating Semantic Transformation

--- a/ipos-agents.ttl
+++ b/ipos-agents.ttl
@@ -4,20 +4,20 @@
 
 <cb/agent/(org_uuid)/issuer> a fibo-fbc-fi-fi:Issuer, fibo-fbc-pas-fpas:Offeror;
   fibo-fnd-rel-rel:issues <cb/ipo/(uuid)/share>;
-  fibo-fnd-rel-rel:hasIdentity <cb/agent/(org_uuid)>.
+  cmns-rlcmp:isPlayedBy <cb/agent/(org_uuid)>.
 
 <cb/exchange/(stock_exchange_symbol)> a fibo-fbc-fct-mkt:Exchange, fibo-fbc-fct-ra:RegistrationAuthority;
   rdfs:label "Exchange '(stock_exchange_symbol)'";
-  fibo-fbc-fct-mkt:hasExchangeAcronym '(stock_exchange_symbol)';
-  lcc-lr:isIdentifiedBy <cb/exchange/(stock_exchange_symbol)/code>.
+  fibo-fbc-fct-mkt:hasFacilityAcronym '(stock_exchange_symbol)';
+  cmns-id:isIdentifiedBy <cb/exchange/(stock_exchange_symbol)/code>.
 
-<cb/exchange/(stock_exchange_symbol)/code> a lcc-lr:Identifier;
+<cb/exchange/(stock_exchange_symbol)/code> a cmns-id:Identifier;
   rdfs:label "Identifier of exchange '(stock_exchange_symbol)'";
-  lcc-lr:hasTag      '(stock_exchange_symbol)';
-  lcc-lr:identifies  <cb/exchange/(stock_exchange_symbol)>;
-  lcc-lr:isMemberOf  <cb/exchange/code>.
+  fibo-fnd-rel-rel:hasTag '(stock_exchange_symbol)';
+  cmns-id:identifies  <cb/exchange/(stock_exchange_symbol)>;
+  cmns-col:isMemberOf  <cb/exchange/code>.
 
-<cb/exchange/code> a lcc-lr:CodeSet;
+<cb/exchange/code> a cmns-cds:CodeSet;
   rdfs:label 'CrunchBase exchange code scheme'.
 
 <cb/ipo/(uuid)/share> a fibo-sec-sec-lst:ListedSecurity, fibo-sec-eq-eq:Share.

--- a/ipos-currencies.ttl
+++ b/ipos-currencies.ttl
@@ -1,46 +1,46 @@
 ## Currencies: USD plus 3 more for the 3 financials
 
 <cb/currency/USD> a fibo-fnd-acc-cur:Currency;
-  lcc-lr:hasName 'USD';
+  cmns-dsg:hasName 'USD';
   rdfs:label 'Currency USD'.
 <cb/currency/USD/code> a fibo-fnd-acc-cur:CurrencyIdentifier;
   rdfs:label 'Code of currency USD';
-  lcc-lr:hasTag 'USD';
-  lcc-lr:denotes <cb/currency/USD>;
-  lcc-lr:identifies <cb/currency/USD>;
-  lcc-lr:isMemberOf <cb/currency>.
+  fibo-fnd-rel-rel:hasTag 'USD';
+  cmns-dsg:denotes <cb/currency/USD>;
+  cmns-id:identifies <cb/currency/USD>;
+  cmns-col:isMemberOf <cb/currency>.
 
 <cb/currency/(share_price_currency_code)> a fibo-fnd-acc-cur:Currency;
-  lcc-lr:hasName '(share_price_currency_code)';
+  cmns-dsg:hasName '(share_price_currency_code)';
   rdfs:label 'Currency (share_price_currency_code)'.
 <cb/currency/(share_price_currency_code)/code> a fibo-fnd-acc-cur:CurrencyIdentifier;
   rdfs:label 'Code of currency (share_price_currency_code)';
-  lcc-lr:hasTag '(share_price_currency_code)';
-  lcc-lr:denotes <cb/currency/(share_price_currency_code)>;
-  lcc-lr:identifies <cb/currency/(share_price_currency_code)>;
-  lcc-lr:isMemberOf <cb/currency>.
+  fibo-fnd-rel-rel:hasTag '(share_price_currency_code)';
+  cmns-dsg:denotes <cb/currency/(share_price_currency_code)>;
+  cmns-id:identifies <cb/currency/(share_price_currency_code)>;
+  cmns-col:isMemberOf <cb/currency>.
 
 <cb/currency/(valuation_price_currency_code)> a fibo-fnd-acc-cur:Currency;
-  lcc-lr:hasName '(valuation_price_currency_code)';
+  cmns-dsg:hasName '(valuation_price_currency_code)';
   rdfs:label 'Currency (valuation_price_currency_code)'.
 <cb/currency/(valuation_price_currency_code)/code> a fibo-fnd-acc-cur:CurrencyIdentifier;
   rdfs:label 'Code of currency (valuation_price_currency_code)';
-  lcc-lr:hasTag '(valuation_price_currency_code)';
-  lcc-lr:denotes <cb/currency/(valuation_price_currency_code)>;
-  lcc-lr:identifies <cb/currency/(valuation_price_currency_code)>;
-  lcc-lr:isMemberOf <cb/currency>.
+  fibo-fnd-rel-rel:hasTag '(valuation_price_currency_code)';
+  cmns-dsg:denotes <cb/currency/(valuation_price_currency_code)>;
+  cmns-id:identifies <cb/currency/(valuation_price_currency_code)>;
+  cmns-col:isMemberOf <cb/currency>.
 
 <cb/currency/(money_raised_currency_code)> a fibo-fnd-acc-cur:Currency;
-  lcc-lr:hasName '(money_raised_currency_code)';
+  cmns-dsg:hasName '(money_raised_currency_code)';
   rdfs:label 'Currency (money_raised_currency_code)'.
 <cb/currency/(money_raised_currency_code)/code> a fibo-fnd-acc-cur:CurrencyIdentifier;
   rdfs:label 'Code of currency (money_raised_currency_code)';
-  lcc-lr:hasTag '(money_raised_currency_code)';
-  lcc-lr:denotes <cb/currency/(money_raised_currency_code)>;
-  lcc-lr:identifies <cb/currency/(money_raised_currency_code)>;
-  lcc-lr:isMemberOf <cb/currency>.
+  fibo-fnd-rel-rel:hasTag '(money_raised_currency_code)';
+  cmns-dsg:denotes <cb/currency/(money_raised_currency_code)>;
+  cmns-id:identifies <cb/currency/(money_raised_currency_code)>;
+  cmns-col:isMemberOf <cb/currency>.
 
-<cb/currency> a lcc-lr:IdentificationScheme, lcc-lr:CodeSet;
+<cb/currency> a cmns-id:IdentificationScheme, cmns-cds:CodeSet;
   rdfs:label 'CrunchBase currency code set';
   skos:definition 'Currency identifiers used in CrunchBase';
   skos:scopeNote 'Better reconcile to fibo-fnd-acc-4217:ISO4217-CodeSet'.

--- a/ipos-fibo.ru
+++ b/ipos-fibo.ru
@@ -1,5 +1,13 @@
 base <https://ontotext.com/crunchbase/resource/>
 prefix cb: <https://ontotext.com/crunchbase/ontology/>
+prefix cmns-cds: <https://www.omg.org/spec/Commons/CodesAndCodeSets/>
+prefix cmns-col: <https://www.omg.org/spec/Commons/Collections/>
+prefix cmns-dsg: <https://www.omg.org/spec/Commons/Designators/>
+prefix cmns-dt: <https://www.omg.org/spec/Commons/DatesAndTimes/>
+prefix cmns-cxtdsg: <https://www.omg.org/spec/Commons/ContextualDesignators/>
+prefix cmns-id: <https://www.omg.org/spec/Commons/Identifiers/>
+prefix cmns-qtu: <https://www.omg.org/spec/Commons/QuantitiesAndUnits/>
+prefix cmns-rlcmp: <https://www.omg.org/spec/Commons/RolesAndCompositions/>
 prefix fibo-fbc-fct-mkt: <https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/Markets/>
 prefix fibo-fbc-fct-ra: <https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/>
 prefix fibo-fbc-fi-fi: <https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/>
@@ -7,15 +15,12 @@ prefix fibo-fbc-pas-fpas: <https://spec.edmcouncil.org/fibo/ontology/FBC/Product
 prefix fibo-fnd-acc-cur: <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/>
 prefix fibo-fnd-agr-ctr: <https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/>
 prefix fibo-fnd-arr-id: <https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/IdentifiersAndIndices/>
-prefix fibo-fnd-dt-fd: <https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/>
 prefix fibo-fnd-rel-rel: <https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/>
-prefix fibo-fnd-utl-alx: <https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/>
 prefix fibo-ind-mkt-bas: <https://spec.edmcouncil.org/fibo/ontology/IND/MarketIndices/BasketIndices/>
 prefix fibo-sec-eq-eq: <https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/>
 prefix fibo-sec-sec-id: <https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIdentification/>
 prefix fibo-sec-sec-iss: <https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/>
 prefix fibo-sec-sec-lst: <https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/>
-prefix lcc-lr: <https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/>
 prefix puml: <http://plantuml.com/ontology#>
 prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 prefix skos: <http://www.w3.org/2004/02/skos/core#>
@@ -33,24 +38,24 @@ insert {graph ?cb_ipos_uuid_URL {
   ## Issuer, Stock exchange
   ?cb_agent_org_uuid_issuer_URL a fibo-fbc-fi-fi:Issuer, fibo-fbc-pas-fpas:Offeror;
     fibo-fnd-rel-rel:issues ?cb_ipo_uuid_share_URL;
-    fibo-fnd-rel-rel:hasIdentity ?cb_agent_org_uuid_URL.
+    cmns-rlcmp:isPlayedBy ?cb_agent_org_uuid_URL.
   ?cb_exchange_stock_exchange_symbol_URL a fibo-fbc-fct-mkt:Exchange, fibo-fbc-fct-ra:RegistrationAuthority;
     rdfs:label "Exchange ?stock_exchange_symbol";
-    fibo-fbc-fct-mkt:hasExchangeAcronym ?stock_exchange_symbol;
-    lcc-lr:isIdentifiedBy ?cb_exchange_stock_exchange_symbol_code_URL.
-  ?cb_exchange_stock_exchange_symbol_code_URL a lcc-lr:Identifier;
+    fibo-fbc-fct-mkt:hasFacilityAcronym ?stock_exchange_symbol;
+    cmns-id:isIdentifiedBy ?cb_exchange_stock_exchange_symbol_code_URL.
+  ?cb_exchange_stock_exchange_symbol_code_URL a cmns-id:Identifier;
     rdfs:label "Identifier of exchange ?stock_exchange_symbol";
-    lcc-lr:hasTag ?stock_exchange_symbol;
-    lcc-lr:identifies ?cb_exchange_stock_exchange_symbol_URL;
-    lcc-lr:isMemberOf <cb/exchange/code>.
-  <cb/exchange/code> a lcc-lr:CodeSet;
+    fibo-fnd-rel-rel:hasTag ?stock_exchange_symbol;
+    cmns-id:identifies ?cb_exchange_stock_exchange_symbol_URL;
+    cmns-col:isMemberOf <cb/exchange/code>.
+  <cb/exchange/code> a cmns-cds:CodeSet;
     rdfs:label 'CrunchBase exchange code scheme'.
   ?cb_ipo_uuid_share_URL a fibo-sec-sec-lst:ListedSecurity, fibo-sec-eq-eq:Share.
   ## Offering, Share, Listing, Ticker
   ?cb_ipo_uuid_offering_URL a fibo-sec-sec-iss:PublicOffering;
     rdfs:label "IPO (permalink)";
     fibo-fbc-pas-fpas:hasOfferingPrice ?cb_ipo_uuid_price_money_raised_currency_code_URL, ?cb_ipo_uuid_price_USD_URL;
-    fibo-fnd-rel-rel:appliesTo ?cb_ipo_uuid_share_URL;
+    cmns-cxtdsg:appliesTo ?cb_ipo_uuid_share_URL;
     fibo-fnd-rel-rel:isIssuedBy ?cb_agent_org_uuid_issuer_URL;
     fibo-sec-sec-iss:hasFirstTradeDate ?went_public_on_xsd_date;
     fibo-sec-sec-iss:isRegisteredWith ?cb_exchange_stock_exchange_symbol_URL;
@@ -72,14 +77,14 @@ insert {graph ?cb_ipos_uuid_URL {
   ?cb_ipo_uuid_listing_URL a fibo-sec-sec-lst:Listing;
     rdfs:label "Listing of share/security ?stock_symbol on exchange ?stock_exchange_symbol";
     fibo-sec-sec-lst:lists ?cb_ipo_uuid_share_URL;
-    lcc-lr:isIdentifiedBy ?cb_ipo_uuid_ticker_URL;
+    cmns-id:isIdentifiedBy ?cb_ipo_uuid_ticker_URL;
     fibo-sec-sec-lst:isTradedOn ?cb_exchange_stock_exchange_symbol_URL;
     fibo-fnd-acc-cur:hasCurrency ?cb_currency_share_price_currency_code_URL.
   ?cb_ipo_uuid_ticker_URL a fibo-sec-sec-id:TickerSymbol, fibo-sec-sec-id:ListedSecurityIdentifier;
     rdfs:label "Ticker symbol/security identifier '(stock_exchange_symbol):(stock_symbol)'";
-    lcc-lr:hasTag ?stock_symbol;
+    fibo-fnd-rel-rel:hasTag ?stock_symbol;
     fibo-fbc-fct-ra:isRegisteredBy ?cb_exchange_stock_exchange_symbol_URL;
-    lcc-lr:identifies ?cb_ipo_uuid_listing_URL;
+    cmns-id:identifies ?cb_ipo_uuid_listing_URL;
     fibo-fnd-arr-id:hasInitialAssignmentDate ?went_public_on_xsd_date.
   <cb/currency/USD> a fibo-fnd-acc-cur:Currency.
   ?cb_currency_share_price_currency_code_URL a fibo-fnd-acc-cur:Currency.
@@ -99,15 +104,15 @@ insert {graph ?cb_ipos_uuid_URL {
   ?cb_ipo_uuid_marketCap_valuation_price_currency_code_URL a fibo-ind-mkt-bas:MarketCapitalization;
     rdfs:label "Market Cap (valuation) at the time of IPO (permalink) in local currency";
     fibo-ind-mkt-bas:hasMarketCapitalizationValue ?cb_ipo_uuid_marketCapValue_valuation_price_currency_code_URL;
-    fibo-fnd-utl-alx:hasArgument ?cb_ipo_uuid_pricePerShare_share_price_currency_code_URL;
-    fibo-fnd-dt-fd:hasObservedDateTime ?went_public_on_xsd_date;
-    fibo-fnd-rel-rel:appliesTo ?cb_agent_org_uuid_issuer_URL.
+    cmns-qtu:hasArgument ?cb_ipo_uuid_pricePerShare_share_price_currency_code_URL;
+    cmns-dt:hasObservedDateTime ?went_public_on_xsd_date;
+    cmns-cxtdsg:appliesTo ?cb_agent_org_uuid_issuer_URL.
   ?cb_ipo_uuid_marketCap_USD_URL a fibo-ind-mkt-bas:MarketCapitalization;
     rdfs:label "Market Cap (valuation) at the time of IPO (permalink) in USD";
     fibo-ind-mkt-bas:hasMarketCapitalizationValue ?cb_ipo_uuid_marketCapValue_USD_URL;
-    fibo-fnd-utl-alx:hasArgument ?cb_ipo_uuid_pricePerShare_USD_URL;
-    fibo-fnd-dt-fd:hasObservedDateTime ?went_public_on_xsd_date;
-    fibo-fnd-rel-rel:appliesTo ?cb_agent_org_uuid_issuer_URL.
+    cmns-qtu:hasArgument ?cb_ipo_uuid_pricePerShare_USD_URL;
+    cmns-dt:hasObservedDateTime ?went_public_on_xsd_date;
+    cmns-cxtdsg:appliesTo ?cb_agent_org_uuid_issuer_URL.
   ?cb_ipo_uuid_marketCapValue_valuation_price_currency_code_URL a fibo-fnd-acc-cur:MonetaryAmount;
     rdfs:label "Monetary amount of Market Cap (valuation) in local currency";
     fibo-fnd-acc-cur:hasAmount ?valuation_price_xsd_decimal;
@@ -120,13 +125,13 @@ insert {graph ?cb_ipos_uuid_URL {
     rdfs:label "Price per share at the time of IPO (permalink) in local currency";
     fibo-fnd-acc-cur:hasAmount ?share_price_xsd_decimal;
     fibo-fnd-acc-cur:hasCurrency ?cb_currency_share_price_currency_code_URL;
-    fibo-fnd-dt-fd:hasObservedDateTime ?went_public_on_xsd_date;
+    cmns-dt:hasObservedDateTime ?went_public_on_xsd_date;
     fibo-fnd-acc-cur:isPriceFor ?cb_ipo_uuid_share_URL.
   ?cb_ipo_uuid_pricePerShare_USD_URL a fibo-sec-eq-eq:PricePerShare;
     rdfs:label "Price per share at the time of IPO (permalink) in USD";
     fibo-fnd-acc-cur:hasAmount ?share_price_usd_xsd_decimal;
     fibo-fnd-acc-cur:hasCurrency <cb/currency/USD>;
-    fibo-fnd-dt-fd:hasObservedDateTime ?went_public_on_xsd_date;
+    cmns-dt:hasObservedDateTime ?went_public_on_xsd_date;
     fibo-fnd-acc-cur:isPriceFor ?cb_ipo_uuid_share_URL.
   <cb/currency/USD> a fibo-fnd-acc-cur:Currency.
   ?cb_currency_share_price_currency_code_URL a fibo-fnd-acc-cur:Currency.
@@ -136,42 +141,42 @@ insert {graph ?cb_ipos_uuid_URL {
   ?cb_agent_org_uuid_issuer_URL a fibo-fbc-fi-fi:Issuer, fibo-fbc-pas-fpas:Offeror.
   ## Currencies: USD plus 3 more for the 3 financials
   <cb/currency/USD> a fibo-fnd-acc-cur:Currency;
-    lcc-lr:hasName 'USD';
+    cmns-dsg:hasName 'USD';
     rdfs:label 'Currency USD'.
   <cb/currency/USD/code> a fibo-fnd-acc-cur:CurrencyIdentifier;
     rdfs:label 'Code of currency USD';
-    lcc-lr:hasTag 'USD';
-    lcc-lr:denotes <cb/currency/USD>;
-    lcc-lr:identifies <cb/currency/USD>;
-    lcc-lr:isMemberOf <cb/currency>.
+    fibo-fnd-rel-rel:hasTag 'USD';
+    cmns-dsg:denotes <cb/currency/USD>;
+    cmns-id:identifies <cb/currency/USD>;
+    cmns-col:isMemberOf <cb/currency>.
   ?cb_currency_share_price_currency_code_URL a fibo-fnd-acc-cur:Currency;
-    lcc-lr:hasName ?share_price_currency_code;
+    cmns-dsg:hasName ?share_price_currency_code;
     rdfs:label 'Currency (share_price_currency_code)'.
   ?cb_currency_share_price_currency_code_code_URL a fibo-fnd-acc-cur:CurrencyIdentifier;
     rdfs:label 'Code of currency (share_price_currency_code)';
-    lcc-lr:hasTag ?share_price_currency_code;
-    lcc-lr:denotes ?cb_currency_share_price_currency_code_URL;
-    lcc-lr:identifies ?cb_currency_share_price_currency_code_URL;
-    lcc-lr:isMemberOf <cb/currency>.
+    fibo-fnd-rel-rel:hasTag ?share_price_currency_code;
+    cmns-dsg:denotes ?cb_currency_share_price_currency_code_URL;
+    cmns-id:identifies ?cb_currency_share_price_currency_code_URL;
+    cmns-col:isMemberOf <cb/currency>.
   ?cb_currency_valuation_price_currency_code_URL a fibo-fnd-acc-cur:Currency;
-    lcc-lr:hasName ?valuation_price_currency_code;
+    cmns-dsg:hasName ?valuation_price_currency_code;
     rdfs:label 'Currency (valuation_price_currency_code)'.
   ?cb_currency_valuation_price_currency_code_code_URL a fibo-fnd-acc-cur:CurrencyIdentifier;
     rdfs:label 'Code of currency (valuation_price_currency_code)';
-    lcc-lr:hasTag ?valuation_price_currency_code;
-    lcc-lr:denotes ?cb_currency_valuation_price_currency_code_URL;
-    lcc-lr:identifies ?cb_currency_valuation_price_currency_code_URL;
-    lcc-lr:isMemberOf <cb/currency>.
+    fibo-fnd-rel-rel:hasTag ?valuation_price_currency_code;
+    cmns-dsg:denotes ?cb_currency_valuation_price_currency_code_URL;
+    cmns-id:identifies ?cb_currency_valuation_price_currency_code_URL;
+    cmns-col:isMemberOf <cb/currency>.
   ?cb_currency_money_raised_currency_code_URL a fibo-fnd-acc-cur:Currency;
-    lcc-lr:hasName ?money_raised_currency_code;
+    cmns-dsg:hasName ?money_raised_currency_code;
     rdfs:label 'Currency (money_raised_currency_code)'.
   ?cb_currency_money_raised_currency_code_code_URL a fibo-fnd-acc-cur:CurrencyIdentifier;
     rdfs:label 'Code of currency (money_raised_currency_code)';
-    lcc-lr:hasTag ?money_raised_currency_code;
-    lcc-lr:denotes ?cb_currency_money_raised_currency_code_URL;
-    lcc-lr:identifies ?cb_currency_money_raised_currency_code_URL;
-    lcc-lr:isMemberOf <cb/currency>.
-  <cb/currency> a lcc-lr:IdentificationScheme, lcc-lr:CodeSet;
+    fibo-fnd-rel-rel:hasTag ?money_raised_currency_code;
+    cmns-dsg:denotes ?cb_currency_money_raised_currency_code_URL;
+    cmns-id:identifies ?cb_currency_money_raised_currency_code_URL;
+    cmns-col:isMemberOf <cb/currency>.
+  <cb/currency> a cmns-id:IdentificationScheme, cmns-cds:CodeSet;
     rdfs:label 'CrunchBase currency code set';
     skos:definition 'Currency identifiers used in CrunchBase';
     skos:scopeNote 'Better reconcile to fibo-fnd-acc-4217:ISO4217-CodeSet'.

--- a/ipos-fibo.ttl
+++ b/ipos-fibo.ttl
@@ -4,20 +4,20 @@
 
 <cb/agent/(org_uuid)/issuer> a fibo-fbc-fi-fi:Issuer, fibo-fbc-pas-fpas:Offeror;
   fibo-fnd-rel-rel:issues <cb/ipo/(uuid)/share>;
-  fibo-fnd-rel-rel:hasIdentity <cb/agent/(org_uuid)>.
+  cmns-rlcmp:isPlayedBy <cb/agent/(org_uuid)>.
 
 <cb/exchange/(stock_exchange_symbol)> a fibo-fbc-fct-mkt:Exchange, fibo-fbc-fct-ra:RegistrationAuthority;
   rdfs:label "Exchange '(stock_exchange_symbol)'";
-  fibo-fbc-fct-mkt:hasExchangeAcronym '(stock_exchange_symbol)';
-  lcc-lr:isIdentifiedBy <cb/exchange/(stock_exchange_symbol)/code>.
+  fibo-fbc-fct-mkt:hasFacilityAcronym '(stock_exchange_symbol)';
+  cmns-id:isIdentifiedBy <cb/exchange/(stock_exchange_symbol)/code>.
 
-<cb/exchange/(stock_exchange_symbol)/code> a lcc-lr:Identifier;
+<cb/exchange/(stock_exchange_symbol)/code> a cmns-id:Identifier;
   rdfs:label "Identifier of exchange '(stock_exchange_symbol)'";
-  lcc-lr:hasTag      '(stock_exchange_symbol)';
-  lcc-lr:identifies  <cb/exchange/(stock_exchange_symbol)>;
-  lcc-lr:isMemberOf  <cb/exchange/code>.
+  fibo-fbc-fct-mkt:hasFacilityAcronym '(stock_exchange_symbol)';
+  cmns-id:identifies  <cb/exchange/(stock_exchange_symbol)>;
+  cmns-col:isMemberOf  <cb/exchange/code>.
 
-<cb/exchange/code> a lcc-lr:CodeSet;
+<cb/exchange/code> a cmns-cds:CodeSet;
   rdfs:label 'CrunchBase exchange code scheme'.
 
 <cb/ipo/(uuid)/share> a fibo-sec-sec-lst:ListedSecurity, fibo-sec-eq-eq:Share.
@@ -27,7 +27,7 @@
 <cb/ipo/(uuid)/offering> a fibo-sec-sec-iss:PublicOffering;
   rdfs:label "IPO (permalink)";
   fibo-fbc-pas-fpas:hasOfferingPrice <cb/ipo/(uuid)/price/(money_raised_currency_code)>, <cb/ipo/(uuid)/price/USD>;
-  fibo-fnd-rel-rel:appliesTo <cb/ipo/(uuid)/share>;
+  cmns-cxtdsg:appliesTo <cb/ipo/(uuid)/share>;
   fibo-fnd-rel-rel:isIssuedBy <cb/agent/(org_uuid)/issuer>;
   fibo-sec-sec-iss:hasFirstTradeDate '(went_public_on)'^^xsd:date;
   fibo-sec-sec-iss:isRegisteredWith <cb/exchange/(stock_exchange_symbol)>;
@@ -51,15 +51,15 @@
 <cb/ipo/(uuid)/listing> a fibo-sec-sec-lst:Listing;
   rdfs:label "Listing of share/security '(stock_symbol)' on exchange '(stock_exchange_symbol)'";
   fibo-sec-sec-lst:lists <cb/ipo/(uuid)/share>;
-  lcc-lr:isIdentifiedBy <cb/ipo/(uuid)/ticker>;
+  cmns-id:isIdentifiedBy <cb/ipo/(uuid)/ticker>;
   fibo-sec-sec-lst:isTradedOn <cb/exchange/(stock_exchange_symbol)>;
   fibo-fnd-acc-cur:hasCurrency <cb/currency/(share_price_currency_code)>.
 
 <cb/ipo/(uuid)/ticker> a fibo-sec-sec-id:TickerSymbol, fibo-sec-sec-id:ListedSecurityIdentifier;
   rdfs:label "Ticker symbol/security identifier '(stock_exchange_symbol):(stock_symbol)'";
-  lcc-lr:hasTag '(stock_symbol)';
+  fibo-fnd-rel-rel:hasTag '(stock_symbol)';
   fibo-fbc-fct-ra:isRegisteredBy <cb/exchange/(stock_exchange_symbol)>;
-  lcc-lr:identifies <cb/ipo/(uuid)/listing>;
+  cmns-id:identifies <cb/ipo/(uuid)/listing>;
   fibo-fnd-arr-id:hasInitialAssignmentDate '(went_public_on)'^^xsd:date.
 
 <cb/currency/USD> a fibo-fnd-acc-cur:Currency.
@@ -84,16 +84,16 @@
 <cb/ipo/(uuid)/marketCap/(valuation_price_currency_code)> a fibo-ind-mkt-bas:MarketCapitalization;
   rdfs:label "Market Cap (valuation) at the time of IPO (permalink) in local currency";
   fibo-ind-mkt-bas:hasMarketCapitalizationValue <cb/ipo/(uuid)/marketCapValue/(valuation_price_currency_code)>;
-  fibo-fnd-utl-alx:hasArgument <cb/ipo/(uuid)/pricePerShare/(share_price_currency_code)>;
-  fibo-fnd-dt-fd:hasObservedDateTime '(went_public_on)'^^xsd:date;
-  fibo-fnd-rel-rel:appliesTo <cb/agent/(org_uuid)/issuer>.
+  cmns-qtu:hasArgument <cb/ipo/(uuid)/pricePerShare/(share_price_currency_code)>;
+  cmns-dt:hasObservedDateTime '(went_public_on)'^^xsd:date;
+  cmns-cxtdsg:appliesTo <cb/agent/(org_uuid)/issuer>.
 
 <cb/ipo/(uuid)/marketCap/USD> a fibo-ind-mkt-bas:MarketCapitalization;
   rdfs:label "Market Cap (valuation) at the time of IPO (permalink) in USD";
   fibo-ind-mkt-bas:hasMarketCapitalizationValue <cb/ipo/(uuid)/marketCapValue/USD>;
-  fibo-fnd-utl-alx:hasArgument <cb/ipo/(uuid)/pricePerShare/USD>;
-  fibo-fnd-dt-fd:hasObservedDateTime '(went_public_on)'^^xsd:date;
-  fibo-fnd-rel-rel:appliesTo <cb/agent/(org_uuid)/issuer>.
+  cmns-qtu:hasArgument <cb/ipo/(uuid)/pricePerShare/USD>;
+  cmns-dt:hasObservedDateTime '(went_public_on)'^^xsd:date;
+  cmns-cxtdsg:appliesTo <cb/agent/(org_uuid)/issuer>.
 
 <cb/ipo/(uuid)/marketCapValue/(valuation_price_currency_code)> a fibo-fnd-acc-cur:MonetaryAmount;
   rdfs:label "Monetary amount of Market Cap (valuation) in local currency";
@@ -109,14 +109,14 @@
   rdfs:label "Price per share at the time of IPO (permalink) in local currency";
   fibo-fnd-acc-cur:hasAmount '(share_price)'^^xsd:decimal;
   fibo-fnd-acc-cur:hasCurrency <cb/currency/(share_price_currency_code)>;
-  fibo-fnd-dt-fd:hasObservedDateTime '(went_public_on)'^^xsd:date;
+  cmns-dt:hasObservedDateTime '(went_public_on)'^^xsd:date;
   fibo-fnd-acc-cur:isPriceFor <cb/ipo/(uuid)/share>.
 
 <cb/ipo/(uuid)/pricePerShare/USD> a fibo-sec-eq-eq:PricePerShare;
   rdfs:label "Price per share at the time of IPO (permalink) in USD";
   fibo-fnd-acc-cur:hasAmount '(share_price_usd)'^^xsd:decimal;
   fibo-fnd-acc-cur:hasCurrency <cb/currency/USD>;
-  fibo-fnd-dt-fd:hasObservedDateTime '(went_public_on)'^^xsd:date;
+  cmns-dt:hasObservedDateTime '(went_public_on)'^^xsd:date;
   fibo-fnd-acc-cur:isPriceFor <cb/ipo/(uuid)/share>.
 
 <cb/currency/USD> a fibo-fnd-acc-cur:Currency.
@@ -128,46 +128,46 @@
 ## Currencies: USD plus 3 more for the 3 financials
 
 <cb/currency/USD> a fibo-fnd-acc-cur:Currency;
-  lcc-lr:hasName 'USD';
+  cmns-dsg:hasName 'USD';
   rdfs:label 'Currency USD'.
 <cb/currency/USD/code> a fibo-fnd-acc-cur:CurrencyIdentifier;
   rdfs:label 'Code of currency USD';
-  lcc-lr:hasTag 'USD';
-  lcc-lr:denotes <cb/currency/USD>;
-  lcc-lr:identifies <cb/currency/USD>;
-  lcc-lr:isMemberOf <cb/currency>.
+  fibo-fnd-rel-rel:hasTag 'USD';
+  cmns-dsg:denotes <cb/currency/USD>;
+  cmns-id:identifies <cb/currency/USD>;
+  cmns-col:isMemberOf <cb/currency>.
 
 <cb/currency/(share_price_currency_code)> a fibo-fnd-acc-cur:Currency;
-  lcc-lr:hasName '(share_price_currency_code)';
+  cmns-dsg:hasName '(share_price_currency_code)';
   rdfs:label 'Currency (share_price_currency_code)'.
 <cb/currency/(share_price_currency_code)/code> a fibo-fnd-acc-cur:CurrencyIdentifier;
   rdfs:label 'Code of currency (share_price_currency_code)';
-  lcc-lr:hasTag '(share_price_currency_code)';
-  lcc-lr:denotes <cb/currency/(share_price_currency_code)>;
-  lcc-lr:identifies <cb/currency/(share_price_currency_code)>;
-  lcc-lr:isMemberOf <cb/currency>.
+  fibo-fnd-rel-rel:hasTag '(share_price_currency_code)';
+  cmns-dsg:denotes <cb/currency/(share_price_currency_code)>;
+  cmns-id:identifies <cb/currency/(share_price_currency_code)>;
+  cmns-col:isMemberOf <cb/currency>.
 
 <cb/currency/(valuation_price_currency_code)> a fibo-fnd-acc-cur:Currency;
-  lcc-lr:hasName '(valuation_price_currency_code)';
+  cmns-dsg:hasName '(valuation_price_currency_code)';
   rdfs:label 'Currency (valuation_price_currency_code)'.
 <cb/currency/(valuation_price_currency_code)/code> a fibo-fnd-acc-cur:CurrencyIdentifier;
   rdfs:label 'Code of currency (valuation_price_currency_code)';
-  lcc-lr:hasTag '(valuation_price_currency_code)';
-  lcc-lr:denotes <cb/currency/(valuation_price_currency_code)>;
-  lcc-lr:identifies <cb/currency/(valuation_price_currency_code)>;
-  lcc-lr:isMemberOf <cb/currency>.
+  fibo-fnd-rel-rel:hasTag '(valuation_price_currency_code)';
+  cmns-dsg:denotes <cb/currency/(valuation_price_currency_code)>;
+  cmns-id:identifies <cb/currency/(valuation_price_currency_code)>;
+  cmns-col:isMemberOf <cb/currency>.
 
 <cb/currency/(money_raised_currency_code)> a fibo-fnd-acc-cur:Currency;
-  lcc-lr:hasName '(money_raised_currency_code)';
+  cmns-dsg:hasName '(money_raised_currency_code)';
   rdfs:label 'Currency (money_raised_currency_code)'.
 <cb/currency/(money_raised_currency_code)/code> a fibo-fnd-acc-cur:CurrencyIdentifier;
   rdfs:label 'Code of currency (money_raised_currency_code)';
-  lcc-lr:hasTag '(money_raised_currency_code)';
-  lcc-lr:denotes <cb/currency/(money_raised_currency_code)>;
-  lcc-lr:identifies <cb/currency/(money_raised_currency_code)>;
-  lcc-lr:isMemberOf <cb/currency>.
+  fibo-fnd-rel-rel:hasTag '(money_raised_currency_code)';
+  cmns-dsg:denotes <cb/currency/(money_raised_currency_code)>;
+  cmns-id:identifies <cb/currency/(money_raised_currency_code)>;
+  cmns-col:isMemberOf <cb/currency>.
 
-<cb/currency> a lcc-lr:IdentificationScheme, lcc-lr:CodeSet;
+<cb/currency> a cmns-id:IdentificationScheme, cmns-cds:CodeSet;
   rdfs:label 'CrunchBase currency code set';
   skos:definition 'Currency identifiers used in CrunchBase';
   skos:scopeNote 'Better reconcile to fibo-fnd-acc-4217:ISO4217-CodeSet'.

--- a/ipos-financials.ttl
+++ b/ipos-financials.ttl
@@ -16,16 +16,16 @@
 <cb/ipo/(uuid)/marketCap/(valuation_price_currency_code)> a fibo-ind-mkt-bas:MarketCapitalization;
   rdfs:label "Market Cap (valuation) at the time of IPO (permalink) in local currency";
   fibo-ind-mkt-bas:hasMarketCapitalizationValue <cb/ipo/(uuid)/marketCapValue/(valuation_price_currency_code)>;
-  fibo-fnd-utl-alx:hasArgument <cb/ipo/(uuid)/pricePerShare/(share_price_currency_code)>;
-  fibo-fnd-dt-fd:hasObservedDateTime '(went_public_on)'^^xsd:date;
-  fibo-fnd-rel-rel:appliesTo <cb/agent/(org_uuid)/issuer>.
+  cmns-qtu:hasArgument <cb/ipo/(uuid)/pricePerShare/(share_price_currency_code)>;
+  cmns-dt:hasObservedDateTime '(went_public_on)'^^xsd:date;
+  cmns-cxtdsg:appliesTo <cb/agent/(org_uuid)/issuer>.
 
 <cb/ipo/(uuid)/marketCap/USD> a fibo-ind-mkt-bas:MarketCapitalization;
   rdfs:label "Market Cap (valuation) at the time of IPO (permalink) in USD";
   fibo-ind-mkt-bas:hasMarketCapitalizationValue <cb/ipo/(uuid)/marketCapValue/USD>;
-  fibo-fnd-utl-alx:hasArgument <cb/ipo/(uuid)/pricePerShare/USD>;
-  fibo-fnd-dt-fd:hasObservedDateTime '(went_public_on)'^^xsd:date;
-  fibo-fnd-rel-rel:appliesTo <cb/agent/(org_uuid)/issuer>.
+  cmns-qtu:hasArgument <cb/ipo/(uuid)/pricePerShare/USD>;
+  cmns-dt:hasObservedDateTime '(went_public_on)'^^xsd:date;
+  cmns-cxtdsg:appliesTo <cb/agent/(org_uuid)/issuer>.
 
 <cb/ipo/(uuid)/marketCapValue/(valuation_price_currency_code)> a fibo-fnd-acc-cur:MonetaryAmount;
   rdfs:label "Monetary amount of Market Cap (valuation) in local currency";
@@ -41,14 +41,14 @@
   rdfs:label "Price per share at the time of IPO (permalink) in local currency";
   fibo-fnd-acc-cur:hasAmount '(share_price)'^^xsd:decimal;
   fibo-fnd-acc-cur:hasCurrency <cb/currency/(share_price_currency_code)>;
-  fibo-fnd-dt-fd:hasObservedDateTime '(went_public_on)'^^xsd:date;
+  cmns-dt:hasObservedDateTime '(went_public_on)'^^xsd:date;
   fibo-fnd-acc-cur:isPriceFor <cb/ipo/(uuid)/share>.
 
 <cb/ipo/(uuid)/pricePerShare/USD> a fibo-sec-eq-eq:PricePerShare;
   rdfs:label "Price per share at the time of IPO (permalink) in USD";
   fibo-fnd-acc-cur:hasAmount '(share_price_usd)'^^xsd:decimal;
   fibo-fnd-acc-cur:hasCurrency <cb/currency/USD>;
-  fibo-fnd-dt-fd:hasObservedDateTime '(went_public_on)'^^xsd:date;
+  cmns-dt:hasObservedDateTime '(went_public_on)'^^xsd:date;
   fibo-fnd-acc-cur:isPriceFor <cb/ipo/(uuid)/share>.
 
 <cb/currency/USD> a fibo-fnd-acc-cur:Currency.

--- a/ipos-offering.ttl
+++ b/ipos-offering.ttl
@@ -3,7 +3,7 @@
 <cb/ipo/(uuid)/offering> a fibo-sec-sec-iss:PublicOffering;
   rdfs:label "IPO (permalink)";
   fibo-fbc-pas-fpas:hasOfferingPrice <cb/ipo/(uuid)/price/(money_raised_currency_code)>, <cb/ipo/(uuid)/price/USD>;
-  fibo-fnd-rel-rel:appliesTo <cb/ipo/(uuid)/share>;
+  cmns-cxtdsg:appliesTo <cb/ipo/(uuid)/share>;
   fibo-fnd-rel-rel:isIssuedBy <cb/agent/(org_uuid)/issuer>;
   fibo-sec-sec-iss:hasFirstTradeDate '(went_public_on)'^^xsd:date;
   fibo-sec-sec-iss:isRegisteredWith <cb/exchange/(stock_exchange_symbol)>;
@@ -27,15 +27,15 @@
 <cb/ipo/(uuid)/listing> a fibo-sec-sec-lst:Listing;
   rdfs:label "Listing of share/security '(stock_symbol)' on exchange '(stock_exchange_symbol)'";
   fibo-sec-sec-lst:lists <cb/ipo/(uuid)/share>;
-  lcc-lr:isIdentifiedBy <cb/ipo/(uuid)/ticker>;
+  cmns-id:isIdentifiedBy <cb/ipo/(uuid)/ticker>;
   fibo-sec-sec-lst:isTradedOn <cb/exchange/(stock_exchange_symbol)>;
   fibo-fnd-acc-cur:hasCurrency <cb/currency/(share_price_currency_code)>.
 
 <cb/ipo/(uuid)/ticker> a fibo-sec-sec-id:TickerSymbol, fibo-sec-sec-id:ListedSecurityIdentifier;
   rdfs:label "Ticker symbol/security identifier '(stock_exchange_symbol):(stock_symbol)'";
-  lcc-lr:hasTag '(stock_symbol)';
+  fibo-fnd-rel-rel:hasTag '(stock_symbol)';
   fibo-fbc-fct-ra:isRegisteredBy <cb/exchange/(stock_exchange_symbol)>;
-  lcc-lr:identifies <cb/ipo/(uuid)/listing>;
+  cmns-id:identifies <cb/ipo/(uuid)/listing>;
   fibo-fnd-arr-id:hasInitialAssignmentDate '(went_public_on)'^^xsd:date.
 
 <cb/currency/USD> a fibo-fnd-acc-cur:Currency.

--- a/prefixes.rq
+++ b/prefixes.rq
@@ -1,6 +1,14 @@
 base         <https://ontotext.com/crunchbase/resource/>
 prefix cb:   <https://ontotext.com/crunchbase/ontology/>
 
+prefix cmns-cds: <https://www.omg.org/spec/Commons/CodesAndCodeSets/>
+prefix cmns-col: <https://www.omg.org/spec/Commons/Collections/>
+prefix cmns-dsg: <https://www.omg.org/spec/Commons/Designators/>
+prefix cmns-dt: <https://www.omg.org/spec/Commons/DatesAndTimes/>
+prefix cmns-cxtdsg: <https://www.omg.org/spec/Commons/ContextualDesignators/>
+prefix cmns-id: <https://www.omg.org/spec/Commons/Identifiers/>
+prefix cmns-qtu: <https://www.omg.org/spec/Commons/QuantitiesAndUnits/>
+prefix cmns-rlcmp: <https://www.omg.org/spec/Commons/RolesAndCompositions/>
 prefix fibo-fbc-fct-mkt: <https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/Markets/>
 prefix fibo-fbc-fct-ra:  <https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/>
 prefix fibo-fbc-fi-fi:   <https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/>
@@ -8,15 +16,12 @@ prefix fibo-fbc-pas-fpas: <https://spec.edmcouncil.org/fibo/ontology/FBC/Product
 prefix fibo-fnd-acc-cur: <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/>
 prefix fibo-fnd-agr-ctr: <https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/>
 prefix fibo-fnd-arr-id:  <https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/IdentifiersAndIndices/>
-prefix fibo-fnd-dt-fd:   <https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/>
 prefix fibo-fnd-rel-rel: <https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/>
-prefix fibo-fnd-utl-alx: <https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/>
 prefix fibo-ind-mkt-bas: <https://spec.edmcouncil.org/fibo/ontology/IND/MarketIndices/BasketIndices/>
 prefix fibo-sec-eq-eq:   <https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/>
 prefix fibo-sec-sec-id:  <https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIdentification/>
 prefix fibo-sec-sec-iss:  <https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/>
 prefix fibo-sec-sec-lst: <https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/>
-prefix lcc-lr:           <https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/>
 
 prefix puml:   <http://plantuml.com/ontology#>
 prefix rdfs:   <http://www.w3.org/2000/01/rdf-schema#>

--- a/prefixes.ttl
+++ b/prefixes.ttl
@@ -2,6 +2,14 @@
 @prefix CB:   <https://ontotext.com/crunchbase/resource/> .
 @prefix cb:   <https://ontotext.com/crunchbase/ontology/> .
 
+@prefix cmns-cds: <https://www.omg.org/spec/Commons/CodesAndCodeSets/> .
+@prefix cmns-col: <https://www.omg.org/spec/Commons/Collections/> .
+@prefix cmns-dsg: <https://www.omg.org/spec/Commons/Designators/> .
+@prefix cmns-dt: <https://www.omg.org/spec/Commons/DatesAndTimes/> .
+@prefix cmns-cxtdsg: <https://www.omg.org/spec/Commons/ContextualDesignators/> .
+@prefix cmns-id: <https://www.omg.org/spec/Commons/Identifiers/> .
+@prefix cmns-qtu: <https://www.omg.org/spec/Commons/QuantitiesAndUnits/> .
+@prefix cmns-rlcmp: <https://www.omg.org/spec/Commons/RolesAndCompositions/> .
 @prefix fibo-fbc-fct-mkt: <https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/Markets/> .
 @prefix fibo-fbc-fct-ra:  <https://spec.edmcouncil.org/fibo/ontology/FBC/FunctionalEntities/RegistrationAuthorities/> .
 @prefix fibo-fbc-fi-fi:   <https://spec.edmcouncil.org/fibo/ontology/FBC/FinancialInstruments/FinancialInstruments/> .
@@ -9,15 +17,12 @@
 @prefix fibo-fnd-acc-cur: <https://spec.edmcouncil.org/fibo/ontology/FND/Accounting/CurrencyAmount/> .
 @prefix fibo-fnd-agr-ctr: <https://spec.edmcouncil.org/fibo/ontology/FND/Agreements/Contracts/> .
 @prefix fibo-fnd-arr-id:  <https://spec.edmcouncil.org/fibo/ontology/FND/Arrangements/IdentifiersAndIndices/> .
-@prefix fibo-fnd-dt-fd:   <https://spec.edmcouncil.org/fibo/ontology/FND/DatesAndTimes/FinancialDates/> .
 @prefix fibo-fnd-rel-rel: <https://spec.edmcouncil.org/fibo/ontology/FND/Relations/Relations/> .
-@prefix fibo-fnd-utl-alx: <https://spec.edmcouncil.org/fibo/ontology/FND/Utilities/Analytics/> .
 @prefix fibo-ind-mkt-bas: <https://spec.edmcouncil.org/fibo/ontology/IND/MarketIndices/BasketIndices/> .
 @prefix fibo-sec-eq-eq:   <https://spec.edmcouncil.org/fibo/ontology/SEC/Equities/EquityInstruments/> .
 @prefix fibo-sec-sec-id:  <https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIdentification/> .
 @prefix fibo-sec-sec-iss:  <https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesIssuance/> .
 @prefix fibo-sec-sec-lst: <https://spec.edmcouncil.org/fibo/ontology/SEC/Securities/SecuritiesListings/> .
-@prefix lcc-lr:           <https://www.omg.org/spec/LCC/Languages/LanguageRepresentation/> .
 
 @prefix puml:   <http://plantuml.com/ontology#> .
 @prefix rdfs:   <http://www.w3.org/2000/01/rdf-schema#> .
@@ -26,14 +31,17 @@
 
 ############ PlantUML instructions
 
-lcc-lr:identifies              puml:arrow puml:up.
-fibo-fnd-rel-rel:hasIdentity   puml:arrow puml:up.
-fibo-fnd-utl-alx:hasArgument   puml:arrow puml:up.
+cmns-cxtdsg:appliesTo          puml:arrow puml:up.
+cmns-id:identifies             puml:arrow puml:up.
+cmns-qtu:hasArgument           puml:arrow puml:up.
+cmns-rlcmp:isPlayedBy          puml:arrow puml:up.
 fibo-fnd-acc-cur:isPriceFor    puml:arrow puml:up.
 fibo-fnd-rel-rel:isIssuedBy    puml:arrow puml:up.
-fibo-fnd-rel-rel:appliesTo     puml:arrow puml:up.
 fibo-fbc-fi-fi:isDenominatedIn puml:arrow puml:down-4.
 
+cmns-cds:CodeSet                      puml:stereotype "(C,lightgreen)".
+cmns-id:IdentificationScheme          puml:stereotype "(S,lightgreen)". # also cmns-cds:CodeSet
+cmns-id:Identifier                    puml:stereotype "(I,lightgreen)".
 fibo-fbc-fct-mkt:Exchange             puml:stereotype "(X,lightblue)".  # also fibo-fbc-fct-ra:RegistrationAuthority
 fibo-fbc-fi-fi:Issuer                 puml:stereotype "(I,lightblue)".  # also fibo-fbc-pas-fpas:Offeror
 fibo-fnd-acc-cur:Currency             puml:stereotype "(C,green)".
@@ -46,6 +54,4 @@ fibo-sec-sec-id:TickerSymbol          puml:stereotype "(T,lightgreen)".
 fibo-sec-sec-iss:PublicOffering       puml:stereotype "(O,yellow)".
 fibo-sec-sec-lst:ListedSecurity       puml:stereotype "(S,yellow)".     # also fibo-sec-eq-eq:Share
 fibo-sec-sec-lst:Listing              puml:stereotype "(L,yellow)".
-lcc-lr:CodeSet                        puml:stereotype "(C,lightgreen)".
-lcc-lr:IdentificationScheme           puml:stereotype "(S,lightgreen)". # also lcc-lr:CodeSet
-lcc-lr:Identifier                     puml:stereotype "(I,lightgreen)".
+


### PR DESCRIPTION
There were numerous revisions since this example was last updated. This includes integration of a number of patterns that are now part of the OMG's Commons Ontology Library v1.1 specification, which is a formal OMG standard, many of which were derived from FIBO and improved on. There is additional content in FIBO in securities and derivatives that was not available when this example was initially created as well.

The example shows how to integrate FIBO with other reference data to demonstrate how to use it, and it would be great to keep it current and augment it with additional content over time.